### PR TITLE
fix to avoid to call alias_method_chain for #to_a twice

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -16,7 +16,7 @@ module ActiveDecorator
         obj.each do |r|
           decorate r
         end
-      elsif defined?(ActiveRecord) && obj.is_a?(ActiveRecord::Relation)
+      elsif defined?(ActiveRecord) && obj.is_a?(ActiveRecord::Relation) && !obj.respond_to?(:to_a_with_decorator)
         class << obj
           def to_a_with_decorator
             to_a_without_decorator.tap do |arr|


### PR DESCRIPTION
Some case, 'alias_method_chain :to_a, :decorator' is called twice, and it cause SystemStackError.
This commit fixes it.
