### PR TITLE
support all helpers in view context

### DIFF
--- a/lib/active_decorator.rb
+++ b/lib/active_decorator.rb
@@ -1,4 +1,3 @@
 require 'active_decorator/version'
 require 'active_decorator/decorator'
 require 'active_decorator/railtie'
-

--- a/lib/active_decorator/helpers.rb
+++ b/lib/active_decorator/helpers.rb
@@ -1,5 +1,3 @@
-require 'action_view'
-
 module ActiveDecorator
   module Helpers
     def method_missing(method, *args, &block)
@@ -7,15 +5,10 @@ module ActiveDecorator
     #TODO need to make sure who raised the error?
     rescue NoMethodError => no_method_error
       begin
-        @@_decorator_view_proxy ||= DecoratorViewProxy.new
-        @@_decorator_view_proxy.send method, *args, &block
+        ActiveDecorator::ViewContext.current.send method, *args, &block
       rescue NoMethodError
         raise no_method_error
       end
-    end
-
-    class DecoratorViewProxy
-      include ::ActionView::Helpers
     end
   end
 end

--- a/lib/active_decorator/railtie.rb
+++ b/lib/active_decorator/railtie.rb
@@ -1,3 +1,4 @@
+require 'active_decorator/view_context'
 require 'rails'
 
 module ActiveDecorator
@@ -8,6 +9,7 @@ module ActiveDecorator
       end
       ActiveSupport.on_load(:action_controller) do
         require 'active_decorator/monkey/abstract_controller/rendering'
+        ActionController::Base.send :include, ActiveDecorator::ViewContext::Filter
       end
       ActiveSupport.on_load(:action_mailer) do
         require 'active_decorator/monkey/abstract_controller/rendering'

--- a/lib/active_decorator/view_context.rb
+++ b/lib/active_decorator/view_context.rb
@@ -1,0 +1,23 @@
+module ActiveDecorator
+  module ViewContext
+    class << self
+      def current
+        Thread.current[:view_context]
+      end
+
+      def current=(view_context)
+        Thread.current[:view_context] = view_context
+      end
+    end
+
+    module Filter
+      extend ActiveSupport::Concern
+
+      included do
+        before_filter do |controller|
+          ActiveDecorator::ViewContext.current = controller.view_context
+        end
+      end
+    end
+  end
+end

--- a/spec/fake_app/books/show.html.erb
+++ b/spec/fake_app/books/show.html.erb
@@ -1,1 +1,2 @@
 <%= @book.link %>
+<%= @book.cover_image %>

--- a/spec/fake_app/fake_app.rb
+++ b/spec/fake_app/fake_app.rb
@@ -54,6 +54,10 @@ module BookDecorator
   def link
     link_to title, 'http://example.com'
   end
+
+  def cover_image
+    image_tag 'cover.png'
+  end
 end
 
 # controllers

--- a/spec/requests/action_view_helpers_spec.rb
+++ b/spec/requests/action_view_helpers_spec.rb
@@ -11,5 +11,6 @@ feature 'fallback to helpers' do
     within 'a' do
       page.should have_content 'RHG'
     end
+    page.should have_css('img')
   end
 end


### PR DESCRIPTION
ActiveDecorator does not correspond to some helpers such as `image_tag`, `url_for`. This patch fix it by delegating method to view context.
