### PR TITLE
Fix generator

### DIFF
--- a/lib/generators/rails/decorator_generator.rb
+++ b/lib/generators/rails/decorator_generator.rb
@@ -15,8 +15,6 @@ Examples:
 DESC
 
       def create_decorator_file
-        empty_directory 'app/decorators'
-
         template 'decorator.rb', File.join('app/decorators', "#{singular_name}_decorator.rb")
       end
 

--- a/lib/generators/rspec/decorator_generator.rb
+++ b/lib/generators/rspec/decorator_generator.rb
@@ -3,8 +3,6 @@ module Rspec
     source_root File.expand_path('../templates', __FILE__)
 
     def create_spec_file
-      empty_directory 'spec/decorators'
-
       template 'decorator_spec.rb', File.join('spec/decorators', "#{singular_name}_decorator_spec.rb")
     end
   end

--- a/lib/generators/test_unit/decorator_generator.rb
+++ b/lib/generators/test_unit/decorator_generator.rb
@@ -3,8 +3,6 @@ module TestUnit
     source_root File.expand_path('../templates', __FILE__)
 
     def create_test_file
-      empty_directory 'test/decorators'
-
       template 'decorator_test.rb', File.join('test/decorators', "#{singular_name}_decorator_test.rb")
     end
   end


### PR DESCRIPTION
When I run following command, `decorator` directory was deleted entirely.

```
$ bundle exec rails destroy decorator user
      remove  app/decorators  # here
      remove  app/decorators/user_decorator.rb
      invoke  rspec
      remove    spec/decorators  # here
      remove    spec/decorators/user_decorator_spec.rb
```

This patch fix it.
