### PR TITLE
Cache nil results for decorator_for.

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -40,7 +40,8 @@ module ActiveDecorator
       d = decorator_name.constantize
       d.send :include, ActiveDecorator::Helpers
       @@decorators[model_class] = d
-      rescue NameError
+    rescue NameError
+      @@decorators[model_class] = nil
     end
   end
 end


### PR DESCRIPTION
This avoids the expensive and repeated calls to constantize for classes where there isn't a corresponding Decorator implementation.

 Given that every single argument to every single render is decorated, our application was spending a long time looking up StringDecorator and FixnumDecorator, with every call generating a NameError, rescuing it and returning nil.  Caching this made a material difference to our rendering time.
