### PR TITLE
Decorate associations of a decorated object

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -28,8 +28,19 @@ module ActiveDecorator
       else
         d = decorator_for obj.class
         return obj unless d
-        obj.extend d unless obj.is_a? d
+        unless obj.is_a? d
+          obj.extend d
+          (class << obj ; self ; end).class_eval do
+            obj.class.reflect_on_all_associations.map(&:name).each do |assoc|
+              define_method(assoc) { |*args|
+                associated = super(*args)
+                Decorator.instance.decorate(associated)
+              }
+            end
+          end
+        end
       end
+      obj
     end
 
     private

--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -37,7 +37,7 @@ module ActiveDecorator
                 Decorator.instance.decorate(associated)
               }
             end
-          end
+          end if obj.class.respond_to? :reflect_on_all_associations
         end
       end
       obj

--- a/spec/fake_app/books/show.html.erb
+++ b/spec/fake_app/books/show.html.erb
@@ -1,2 +1,3 @@
 <%= @book.link %>
 <%= @book.cover_image %>
+<%= @book.attribution %>

--- a/spec/fake_app/fake_app.rb
+++ b/spec/fake_app/fake_app.rb
@@ -58,6 +58,10 @@ module BookDecorator
   def cover_image
     image_tag 'cover.png'
   end
+
+  def attribution
+    "#{title}, by #{author.capitalized_name}"
+  end
 end
 
 # controllers

--- a/spec/requests/action_view_helpers_spec.rb
+++ b/spec/requests/action_view_helpers_spec.rb
@@ -12,5 +12,6 @@ feature 'fallback to helpers' do
       page.should have_content 'RHG'
     end
     page.should have_css('img')
+    page.should have_content 'RHG, by Aamine'
   end
 end


### PR DESCRIPTION
Hi, I just started using active_decorator, it seems great, thanks for making it!

But I quickly came across a feature that I needed: the ability to access an association's decorations.  That is, considering the `Book` and `Author` classes in `spec/fake_app` --  I wanted to create a method in `BookDecoration` like:

```
def attribution
     "#{title}, by #{author.capitalized_name}"
end
```

which uses `AuthorDecoration#capitalized_name`.  But typically although `self` is decorated, `se;f.author` is not decorated so the method fails.

The solution I came up with is, after decorating an object, to introspect on all associations and override their methods in the object's singleton class, to call super() and return the decorated result.   This approach seems to work, and has the feature of being "lazy" in that the associated objects only get decorated if/when they're accessed.  I don't think it will conflict with anything else, though I'll admit I haven't put very deep thought into it.   

Cheers
