### PR TITLE
Use === to know whether the object is Array or not

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -12,7 +12,7 @@ module ActiveDecorator
     def decorate(obj)
       return if obj.nil?
 
-      if obj.is_a? Array
+      if Array === obj
         obj.each do |r|
           decorate r
         end


### PR DESCRIPTION
Using `#is_a?` could be a problem if the object doesn't have such a method. The issue often happens when we use a class that inherits `BasicObject` like [Jbuilder](https://github.com/rails/jbuilder).

This patch fixes the issue and ActiveDecorator does work with Jbuilder now.
