### PR TITLE
Still return object when it is already decorated

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -29,6 +29,7 @@ module ActiveDecorator
         d = decorator_for obj.class
         return obj unless d
         obj.extend d unless obj.is_a? d
+        obj
       end
     end
 

--- a/spec/lib/decorator_spec.rb
+++ b/spec/lib/decorator_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe ActiveDecorator::Decorator do
+  subject { ActiveDecorator::Decorator.instance }
+  let(:book) { Book.new(title: 'Boek') }
+
+  it 'returns the object on decoration' do
+    subject.decorate(book).should == book
+  end
+
+  it "returns the object when it already is decorated on decorate" do
+    subject.decorate(subject.decorate(book)).should == book
+  end
+end


### PR DESCRIPTION
When decorate is called for an object that is already decorated nil is returned. Returning the object itself is more normal behavior.
