### PR TITLE
If no decorator is found, fall back to decorators for parent classes

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -36,16 +36,21 @@ module ActiveDecorator
     def decorator_for(model_class)
       return @@decorators[model_class] if @@decorators.has_key? model_class
 
-      decorator_name = "#{model_class.name}Decorator"
-      d = decorator_name.constantize
-      unless Class === d
-        d.send :include, ActiveDecorator::Helpers
-        @@decorators[model_class] = d
-      else
-        @@decorators[model_class] = nil
+      (model_class.ancestors - model_class.included_modules).find do |candidate|
+        decorator_name = "#{candidate.name}Decorator"
+
+        begin
+          d = decorator_name.constantize
+
+          unless Class === d
+            d.send :include, ActiveDecorator::Helpers
+            @@decorators[model_class] = d
+            return d
+          end
+        rescue NameError
+          next
+        end
       end
-    rescue NameError
-      @@decorators[model_class] = nil
     end
   end
 end

--- a/spec/decorator_spec.rb
+++ b/spec/decorator_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe ActiveDecorator::Decorator do
+  subject do
+    ActiveDecorator::Decorator.instance
+  end
+
+  describe '#decorator_for' do
+    context 'when a decorator exists' do
+      it 'returns the decorator' do
+        subject.send(:decorator_for, Parent).should == ParentDecorator
+      end
+    end
+
+    context 'when a parent decorator exists' do
+      it 'returns the decorator' do
+        subject.send(:decorator_for, Child).should == ParentDecorator
+      end
+    end
+  end
+end
+
+class Parent
+end
+
+class Child < Parent
+end
+
+module ParentDecorator
+end


### PR DESCRIPTION
I use single table inheritance quite a lot so I made this in order to avoid having to create a decorator for every single child class if all I need is common functionality.

With this change, a class `Child` that inherits from `Parent` will be decorated with `ParentDecorator` if no `ChildDecorator` exists.

I considered making it so that both `ChildDecorator` and `ParentDecorator` would be included of both exist but I am not sure if that is a good idea. Now I just include `ParentDecorator` in my `ChildDecorator` manually which works just fine.
