### PR TITLE
Fix AR::CollectionProxy is not decorated.

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -12,7 +12,7 @@ module ActiveDecorator
     def decorate(obj)
       return if obj.nil?
 
-      if Array === obj
+      if obj.is_a?(Array)
         obj.each do |r|
           decorate r
         end

--- a/spec/fake_app/books/index.html.erb
+++ b/spec/fake_app/books/index.html.erb
@@ -1,0 +1,4 @@
+<% @books.each do |book| %>
+  <%= book.title %>
+  <%= book.reverse_title %>
+<% end %>

--- a/spec/fake_app/fake_app.rb
+++ b/spec/fake_app/fake_app.rb
@@ -17,7 +17,7 @@ ActiveDecoratorTestApp::Application.initialize!
 # routes
 ActiveDecoratorTestApp::Application.routes.draw do
   resources :authors, :only => [:index, :show] do
-    resources :books, :only => :show
+    resources :books, :only => [:index, :show]
   end
   resources :movies, :only => :show
 end
@@ -84,6 +84,11 @@ class AuthorsController < ApplicationController
   end
 end
 class BooksController < ApplicationController
+  def index
+    @author = Author.find params[:author_id]
+    @books  = @author.books
+  end
+
   def show
     @book = Author.find(params[:author_id]).books.find(params[:id])
   end

--- a/spec/features/controller_ivar_spec.rb
+++ b/spec/features/controller_ivar_spec.rb
@@ -3,10 +3,13 @@ require 'spec_helper'
 feature 'decorating controller ivar' do
   background do
     @matz = Author.create! :name => 'matz'
+    @matz.books.create! :title => 'the world of code'
     Author.create! :name => 'takahashim'
   end
+
   after do
     Author.delete_all
+    Book.delete_all
   end
 
   scenario 'decorating a model object in ivar' do
@@ -25,5 +28,11 @@ feature 'decorating controller ivar' do
     visit '/authors?variable_type=array'
     page.should have_content 'takahashim'
     page.should have_content 'takahashim'.reverse
+  end
+
+  scenario 'decorating model association proxy in ivar' do
+    visit "/authors/#{@matz.id}/books"
+    page.should have_content 'the world of code'
+    page.should have_content 'the world of code'.reverse
   end
 end


### PR DESCRIPTION
`Array === <an instance of CollectionProxy>` returns `false` on at least AR-3.2.13.

I wonder why `obj.is_a?(Array)` was changed on 9abf6bb.