### PR TITLE
Add 'respond_to_missing?' to ActiveDecorator::Helper

### DIFF
--- a/lib/active_decorator/helpers.rb
+++ b/lib/active_decorator/helpers.rb
@@ -10,5 +10,11 @@ module ActiveDecorator
         raise original_error
       end
     end
+
+    if RUBY_VERSION >= '1.9.3'
+      def respond_to_missing?(method, include_private)
+        ActiveDecorator::ViewContext.current.respond_to?(method, include_private)
+      end
+    end
   end
 end

--- a/spec/fake_app/authors/show.html.erb
+++ b/spec/fake_app/authors/show.html.erb
@@ -1,2 +1,3 @@
 <%= @author.name %>
 <%= @author.capitalized_name %>
+<%= @author.current_user_id_respond_to? %>

--- a/spec/fake_app/fake_app.rb
+++ b/spec/fake_app/fake_app.rb
@@ -44,6 +44,10 @@ module AuthorDecorator
   def capitalized_name
     name.capitalize
   end
+
+  def current_user_id_respond_to?
+    respond_to?(:current_user_id)
+  end
 end
 module BookDecorator
   def reverse_title
@@ -69,6 +73,11 @@ class MovieDecorator; end
 # controllers
 class ApplicationController < ActionController::Base
   self.append_view_path File.dirname(__FILE__)
+  private
+  def current_user_id
+    1
+  end
+  helper_method :current_user_id
 end
 class AuthorsController < ApplicationController
   def index

--- a/spec/features/action_view_helpers_spec.rb
+++ b/spec/features/action_view_helpers_spec.rb
@@ -13,4 +13,9 @@ feature 'fallback to helpers' do
     end
     page.should have_css('img')
   end
+
+  scenario 'When invoked respond_to? in decorator, delegate to view_context' do
+    visit "/authors/#{@rhg.author.id}"
+    page.should have_content('true')
+  end
 end


### PR DESCRIPTION
When  I want to detect a helper method that is defined in a controller,
I must write like following.

``` ruby
module SampleDecorator
  def invoke_helper_method
    ActiveDecorator::ViewContext.current.respond_to?(:helper_method) ? helper_method : nil
  end
end
```

this patch enable to write in this way.

``` ruby
module SampleDecorator
  def invoke_helper_method
    respond_to?(:helper_method) ? helper_method : nil
  end
end
```
