### PR TITLE
Fix rspec deprecation

### DIFF
--- a/spec/controllers/fake_detection_spec.rb
+++ b/spec/controllers/fake_detection_spec.rb
@@ -4,6 +4,6 @@ describe MoviesController do
   let(:movie){ Movie.create }
 
   it 'reveals fakes' do
-    expect{ get :show, :id => movie.id }.not_to raise_error(TypeError)
+    expect{ get :show, :id => movie.id }.not_to raise_error
   end
 end


### PR DESCRIPTION
Hi, just fixed the next rspec deprecation message.

DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error` (with no args) instead. 

Please see the discussion below for details.
https://github.com/rspec/rspec-expectations/issues/231