### PR TITLE
Cutomize `#{name}Decorator` name convention

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -5,8 +5,16 @@ module ActiveDecorator
   class Decorator
     include Singleton
 
+    DEFAULT_NAME_RESOLVER = lambda {|model_class| "#{model_class.name}Decorator" }
+
     def initialize
-      @@decorators = {}
+      @@decorators   = {}
+      @name_resolver = DEFAULT_NAME_RESOLVER
+    end
+
+    def resolve_decorator_with(&block)
+      @@decorators.clear
+      @name_resolver = block
     end
 
     def decorate(obj)
@@ -36,7 +44,7 @@ module ActiveDecorator
     def decorator_for(model_class)
       return @@decorators[model_class] if @@decorators.has_key? model_class
 
-      decorator_name = "#{model_class.name}Decorator"
+      decorator_name = @name_resolver.call(model_class)
       d = decorator_name.constantize
       unless Class === d
         d.send :include, ActiveDecorator::Helpers

--- a/spec/active_decorator/decorator_spec.rb
+++ b/spec/active_decorator/decorator_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+class MyModel
+end
+
+module MyModelPresenter
+  def greet
+    'Hi from Presenter'
+  end
+end
+
+describe ActiveDecorator::Decorator do
+  context 'customize decorator name resolving' do
+    before(:all) do
+      ActiveDecorator::Decorator.instance.resolve_decorator_with do |name|
+        "#{name}Presenter"
+      end
+    end
+
+    after(:all) do
+      ActiveDecorator::Decorator.instance.resolve_decorator_with(&ActiveDecorator::Decorator::DEFAULT_NAME_RESOLVER)
+    end
+
+    let(:my_model) do
+      ActiveDecorator::Decorator.instance.decorate(MyModel.new)
+    end
+
+    specify { my_model.greet.should == 'Hi from Presenter' }
+  end
+end
+


### PR DESCRIPTION
Some framework (and/or project rule) occupies `base + "Decorator"` convention.

To use active_decorator in such a scene, it's better there's a way to customize naming convention, is'nt it?