### PR TITLE
supported rails_helper.rb

### DIFF
--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require 'spec_helper'
+require '<%= File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
 
 describe <%= singular_name.camelize %>Decorator do
   let(:<%= singular_name %>) { <%= class_name %>.new.extend <%= singular_name.camelize %>Decorator }


### PR DESCRIPTION
generator of rspec did not support existing rails_helper.rb from RSpec3, I coped.