### PR TITLE
Add ViewContext::Filter include to ActionMailer::Base

### DIFF
--- a/lib/active_decorator/railtie.rb
+++ b/lib/active_decorator/railtie.rb
@@ -13,6 +13,7 @@ module ActiveDecorator
       end
       ActiveSupport.on_load(:action_mailer) do
         require 'active_decorator/monkey/abstract_controller/rendering'
+        ActionMailer::Base.send :include, ActiveDecorator::ViewContext::Filter
       end
     end
   end


### PR DESCRIPTION
When `ActionMailer::Base` is delivered by Model or Worker(like ActiveJob) method,
`ActiveDecorator::ViewContext.current` is `nil` and I cannot use view helper methods in decorator.
the reason is that `ActionMailer::Base` inherits `AbstractController::Base`,
but only ActionController::Base set view_context.

It becomes the problem mainly when I use `ActionMailer::Base#deliver_later` with active_decorator.