### PR TITLE
configurable Decorator Name Suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ end
 <% end %>
 ```
 
+## Configuration
+
+If you want to use other decorator suffix, you can configurate.
+
+```
+ActiveDecorator.configure do |config|
+  config.decorator_suffix = 'Presenter'
+end
+```
+
 ## Contributing to ActiveDecorator ##
 
 * Fork, fix, then send me a pull request.

--- a/lib/active_decorator.rb
+++ b/lib/active_decorator.rb
@@ -1,3 +1,4 @@
 require 'active_decorator/version'
 require 'active_decorator/decorator'
 require 'active_decorator/railtie'
+require 'active_decorator/config'

--- a/lib/active_decorator/config.rb
+++ b/lib/active_decorator/config.rb
@@ -1,0 +1,20 @@
+module ActiveDecorator
+  def self.configure(&block)
+    yield @config ||= ActiveDecorator::Configuration.new
+  end
+
+  def self.config
+    @config
+  end
+
+  # need a Class for 3.0
+  class Configuration #:nodoc:
+    include ActiveSupport::Configurable
+
+    config_accessor :decorator_suffix
+  end
+
+  configure do |config|
+    config.decorator_suffix = 'Decorator'
+  end
+end

--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -37,7 +37,7 @@ module ActiveDecorator
     def decorator_for(model_class)
       return @@decorators[model_class] if @@decorators.has_key? model_class
 
-      decorator_name = "#{model_class.name}Decorator"
+      decorator_name = "#{model_class.name}#{ActiveDecorator.config.decorator_suffix}"
       d = decorator_name.constantize
       unless Class === d
         d.send :include, ActiveDecorator::Helpers

--- a/spec/model/configure_spec.rb
+++ b/spec/model/configure_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+class Comic
+  def presenter
+    'decorator'
+  end
+end
+
+module ComicPresenter
+  def presenter
+    'presenter'
+  end
+end
+
+describe 'Configure' do
+  let(:comic) { Comic.new }
+
+  before do
+    ActiveDecorator.configure do |config|
+      config.decorator_suffix = 'Presenter'
+    end
+
+    ActiveDecorator::Decorator.instance.decorate(comic)
+  end
+
+  after do
+    ActiveDecorator.configure do |config|
+      config.decorator_suffix = 'Decorator'
+    end
+  end
+
+  it 'must use MoviePresenter' do
+    expect(comic.presenter).to eq 'presenter'
+  end
+end


### PR DESCRIPTION
I have to be able to set decorator name suffix.
(This is a matter that has been talk on Asakusa.rb meetup.)

We can use the 'FooPresenter' instead of 'FooDecorator'.

```
ActiveDecorator::Config.configuration do |config|
  config.decorator_suffix = 'Presenter'
end
```
