### PR TITLE
Use class_eval not singleton class when decorating ActiveRecord::Relation object

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -18,7 +18,7 @@ module ActiveDecorator
           decorate r
         end
       elsif defined?(ActiveRecord) && obj.is_a?(ActiveRecord::Relation) && !obj.respond_to?(:to_a_with_decorator)
-        class << obj
+        obj.class.class_eval do
           def to_a_with_decorator
             to_a_without_decorator.tap do |arr|
               ActiveDecorator::Decorator.instance.decorate arr

--- a/spec/features/controller_ivar_spec.rb
+++ b/spec/features/controller_ivar_spec.rb
@@ -30,6 +30,12 @@ feature 'decorating controller ivar' do
     page.should have_content 'takahashim'.reverse
   end
 
+  scenario "decorating models' proxy object in ivar" do
+    visit '/authors?variable_type=proxy'
+    page.should have_content 'takahashim'
+    page.should have_content 'takahashim'.reverse
+  end
+
   scenario 'decorating model association proxy in ivar' do
     visit "/authors/#{@matz.id}/books"
     page.should have_content 'the world of code'


### PR DESCRIPTION
### Problem to solve

Consider the case that a object which will decorate implements Proxy pattern, inherits the BasicObject and is using method_missing.

When proxy destination object is `ActiveRecord::Relation` like [Octopus::RelationProxy](https://github.com/tchandy/octopus/blob/master/lib/octopus/relation_proxy.rb) of [Octopus](https://github.com/tchandy/octopus), `alias_method_chain :to_a, :decorator` in `ActiveDecorator::Decorator#decorate` raises following error.

```
NameError:
       undefined method `to_a' for class `Octopus::RelationProxy'
```

This is due to that confirmation of the object (`obj.is_a?(ActiveRecord::Relation)`) is executed on the proxy destination object, but alias operation of the method (`alias_method_chain: to_a,: decorator`) is executed in the singleton class of obj. The singleton class does not find `to_a` method because the `obj` is not a ActiveRecord::Relation but a Proxy class.

### In this Pull Request

The alias operation against `obj.class` not a singleton class.
Because both confirmation of object and alias operation should be made to the same object.
