### PR TITLE
Extract monkey patch for `AR::Relation` extension

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -13,18 +13,9 @@ module ActiveDecorator
       return if defined?(Jbuilder) && Jbuilder === obj
       return if obj.nil?
 
-      if obj.is_a?(Array)
+      if obj.is_a?(Array) || obj.is_a?(ActiveRecord::Relation)
         obj.each do |r|
           decorate r
-        end
-      elsif defined?(ActiveRecord) && obj.is_a?(ActiveRecord::Relation) && !obj.respond_to?(:to_a_with_decorator)
-        obj.class.class_eval do
-          def to_a_with_decorator
-            to_a_without_decorator.tap do |arr|
-              ActiveDecorator::Decorator.instance.decorate arr
-            end
-          end
-          alias_method_chain :to_a, :decorator
         end
       else
         d = decorator_for obj.class

--- a/lib/active_decorator/monkey/active_record/relation.rb
+++ b/lib/active_decorator/monkey/active_record/relation.rb
@@ -1,0 +1,8 @@
+class ActiveRecord::Relation
+  def to_a_with_decorator
+    to_a_without_decorator.tap do |arr|
+      ActiveDecorator::Decorator.instance.decorate arr
+    end
+  end
+  alias_method_chain :to_a, :decorator
+end

--- a/lib/active_decorator/railtie.rb
+++ b/lib/active_decorator/railtie.rb
@@ -4,6 +4,9 @@ require 'rails'
 module ActiveDecorator
   class Railtie < ::Rails::Railtie
     initializer 'active_decorator' do
+      ActiveSupport.on_load(:active_record) do
+        require 'active_decorator/monkey/active_record/relation'
+      end
       ActiveSupport.on_load(:action_view) do
         require 'active_decorator/monkey/action_view/partial_renderer'
       end


### PR DESCRIPTION
Don't extend class behavior in dynamically.
It is thread un-safe :bomb:

But this commit changes the behavior:
* Previous: `ActiveRecord::Relation#to_a` is extended.
* Current: The subclass of `ActiveRecord::Relation`'s  `to_a` is extended.

I'm not sure that this affects any impact to existing code. 
Could you review this one? @amatsuda 