### PR TITLE
Drop test for Ruby 1.8 & 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 script: bundle exec rake spec
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2.3
@@ -17,17 +16,6 @@ gemfile:
 sudo: false
 
 matrix:
-  include:
-    - rvm: 1.8.7
-      gemfile: gemfiles/Gemfile-rails.3.0.x
-    - rvm: 1.8.7
-      gemfile: gemfiles/Gemfile-rails.3.1.x
-    - rvm: 1.8.7
-      gemfile: gemfiles/Gemfile-rails.3.2.x
-    - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile-rails.3.0.x
-    - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile-rails.3.1.x
   exclude:
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile-rails.3.2.x


### PR DESCRIPTION
Now, there are obsolete.