### PR TITLE
Remove duplicated `delete_all`

### DIFF
--- a/spec/features/controller_ivar_spec.rb
+++ b/spec/features/controller_ivar_spec.rb
@@ -5,11 +5,6 @@ feature 'decorating controller ivar' do
     Author.create! :name => 'takahashim'
   end
 
-  after do
-    Author.delete_all
-    Book.delete_all
-  end
-
   scenario 'decorating a model object in ivar' do
     visit "/authors/#{@matz.id}"
     page.should have_content 'matz'

--- a/spec/features/jbuilder_spec.rb
+++ b/spec/features/jbuilder_spec.rb
@@ -4,10 +4,6 @@ feature 'decorating partial object in Jbuilder' do
     nari = Author.create! :name => 'nari'
     nari.books.create! :title => 'the gc book'
   end
-  after do
-    Book.delete_all
-    Author.delete_all
-  end
 
   scenario 'decorating objects in Jbuilder partials' do
     visit "/authors/#{Author.last.id}.json"

--- a/spec/features/partial_spec.rb
+++ b/spec/features/partial_spec.rb
@@ -4,10 +4,6 @@ feature 'decorating partial object' do
     nari = Author.create! :name => 'nari'
     nari.books.create! :title => 'the gc book'
   end
-  after do
-    Book.delete_all
-    Author.delete_all
-  end
 
   scenario 'decorating implicit @object' do
     visit '/authors'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ RSpec.configure do |config|
   config.before :all do
     CreateAllTables.up unless ActiveRecord::Base.connection.table_exists? 'authors'
   end
+
   config.before :each do
     Book.delete_all
     Author.delete_all


### PR DESCRIPTION
We `delete_all` all models in "spec_helper.rb"'s before block.