### PR TITLE
Ensure idempotence on decorate method

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -24,6 +24,7 @@ module ActiveDecorator
         d = decorator_for obj.class
         return obj unless d
         obj.extend d unless obj.is_a? d
+        obj
       end
     end
 

--- a/test/double_decorate_test.rb
+++ b/test/double_decorate_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+Comic = Struct.new(:title, :price)
+
+module ComicPresenter
+  def price
+    "$#{super}"
+  end
+end
+
+class DoubleDecorateTest < Test::Unit::TestCase
+  test 'with decorate idempotence' do
+    comic = ActiveDecorator::Decorator.instance.decorate Comic.new("amatsuda's (Poignant) Guide to ActiveDecorator", 3)
+    comic = ActiveDecorator::Decorator.instance.decorate comic
+    assert_equal '$3', comic.price
+  end
+end


### PR DESCRIPTION
Right now, if you (somehow) end up calling `decorate` method twice, it falls into return value of `nil`.
I want to make it idempotent so that it always returns `obj`.

Btw, thank you so much for creating awesome gems :smile: 
