### PR TITLE
Test against edge Rails instead of Rails 5.0.0.beta3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ gemfile:
   - gemfiles/Gemfile-rails.4.0.x
   - gemfiles/Gemfile-rails.4.1.x
   - gemfiles/Gemfile-rails.4.2.x
-  - gemfiles/Gemfile-rails.5.0.0.beta3
+  - gemfiles/Gemfile-rails.edge
 
 sudo: false
 
@@ -22,8 +22,8 @@ matrix:
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile-rails.3.2.x
     - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile-rails.5.0.0.beta3
+      gemfile: gemfiles/Gemfile-rails.edge
     - rvm: 2.1.10
-      gemfile: gemfiles/Gemfile-rails.5.0.0.beta3
+      gemfile: gemfiles/Gemfile-rails.edge
   allow_failures:
     - rvm: ruby-head

--- a/gemfiles/Gemfile-rails.edge
+++ b/gemfiles/Gemfile-rails.edge
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'active_decorator', path: '..'
 
-gem 'rails', '~> 5.0.0.beta3'
+gem 'rails', github: 'rails/rails'
 gem 'test-unit-rails'
 gem 'capybara'
 gem 'sqlite3'


### PR DESCRIPTION
Because `test-unit-rails` gem does not run on Rails 5.0.0.beta3,
change to run test on edge Rails.