### PR TITLE
Ensure NameError in decorator is properly handled

### DIFF
--- a/lib/active_decorator/helpers.rb
+++ b/lib/active_decorator/helpers.rb
@@ -3,11 +3,11 @@ module ActiveDecorator
     def method_missing(method, *args, &block)
       super
     #TODO need to make sure who raised the error?
-    rescue NoMethodError, NameError => original_error
+    rescue NoMethodError, NameError
       begin
-        ActiveDecorator::ViewContext.current.send method, *args, &block
+        (view_context = ActiveDecorator::ViewContext.current).send method, *args, &block
       rescue NoMethodError, NameError
-        raise original_error
+        raise NameError, "undefined local variable or method `#{method}` for either #{self} or #{view_context}"
       end
     end
   end

--- a/test/fake_app/app/views/books/errata.html.erb
+++ b/test/fake_app/app/views/books/errata.html.erb
@@ -1,0 +1,1 @@
+<%= @book.errata %>

--- a/test/fake_app/fake_app.rb
+++ b/test/fake_app/fake_app.rb
@@ -27,6 +27,7 @@ ActiveDecoratorTestApp::Application.routes.draw do
   resources :authors, only: [:index, :show] do
     resources :books, only: [:index, :show] do
       member do
+        get :errata
         get :error
         post :purchase
       end
@@ -83,6 +84,10 @@ module BookDecorator
     image_tag 'cover.png'
   end
 
+  def errata
+    poof!
+  end
+
   def error
     "ERROR"
   end
@@ -135,6 +140,10 @@ class BooksController < ApplicationController
   end
 
   def show
+    @book = Author.find(params[:author_id]).books.find(params[:id])
+  end
+
+  def errata
     @book = Author.find(params[:author_id]).books.find(params[:id])
   end
 

--- a/test/features/name_error_handling_test.rb
+++ b/test/features/name_error_handling_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class NameErrorHandlingTest < ActionDispatch::IntegrationTest
+  setup do
+    aamine = Author.create! name: 'aamine'
+    @rhg = aamine.books.create! title: 'RHG'
+  end
+
+  test 'raising NameError in a decorator' do
+    err = assert_raises ActionView::Template::Error do
+      visit "/authors/#{@rhg.author.id}/books/#{@rhg.id}/errata"
+    end
+
+    assert_match /undefined local variable or method `poof!` for/, err.message
+  end
+end


### PR DESCRIPTION
This fixes issue #70 by ensuring a ```NameError``` (wrapped in ```ActionView::Template::Error``` by rails) is properly raised when a ```NameError``` occurs in a decorator method.