### PR TITLE
Fix generated tests for models with nested module

### DIFF
--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -1,7 +1,7 @@
 require '<%= File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
 
-describe <%= singular_name.camelize %>Decorator do
-  let(:<%= singular_name %>) { <%= class_name %>.new.extend <%= singular_name.camelize %>Decorator }
+describe <%= class_name %>Decorator do
+  let(:<%= singular_name %>) { <%= class_name %>.new.extend <%= class_name %>Decorator }
   subject { <%= singular_name %> }
   it { should be_a <%= class_name %> }
 end

--- a/lib/generators/test_unit/templates/decorator_test.rb
+++ b/lib/generators/test_unit/templates/decorator_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class <%= singular_name.camelize %>DecoratorTest < ActiveSupport::TestCase
   def setup
-    @<%= singular_name %> = <%= class_name %>.new.extend <%= singular_name.camelize %>Decorator
+    @<%= singular_name %> = <%= class_name %>.new.extend <%= class_name %>Decorator
   end
 
   # test "the truth" do


### PR DESCRIPTION
* `rails g decorator A::B` generates A::BDecorator, but the corresponding test/spec file
  tries to refer it as BDecorator
* Such model names are commin if you use model from a Rails Engine