### PR TITLE
Fix decorates associations for Rails 5.1 or higher

### DIFF
--- a/lib/active_decorator/monkey/active_record/associations.rb
+++ b/lib/active_decorator/monkey/active_record/associations.rb
@@ -11,23 +11,43 @@ module ActiveDecorator
         end
 
         module CollectionAssociation
-          private
+          if Rails.version.to_f < 5.1
+            private
 
-          # @see https://github.com/rails/rails/commit/03855e790de2224519f55382e3c32118be31eeff
-          if Rails.version.to_f < 4.1
-            def first_or_last(*)
-              ActiveDecorator::Decorator.instance.decorate_association(owner, super)
-            end
-          else
-            def first_nth_or_last(*)
-              ActiveDecorator::Decorator.instance.decorate_association(owner, super)
+            # @see https://github.com/rails/rails/commit/03855e790de2224519f55382e3c32118be31eeff
+            if Rails.version.to_f < 4.1
+              def first_or_last(*)
+                ActiveDecorator::Decorator.instance.decorate_association(owner, super)
+              end
+            else
+              def first_nth_or_last(*)
+                ActiveDecorator::Decorator.instance.decorate_association(owner, super)
+              end
             end
           end
         end
 
         module CollectionProxy
-          def take(limit = nil)
-            ActiveDecorator::Decorator.instance.decorate_association(@association.owner, super)
+          if Rails.version.to_f >= 4.0
+            def take(limit = nil)
+              ActiveDecorator::Decorator.instance.decorate_association(@association.owner, super)
+            end
+          end
+
+          if Rails.version.to_f >= 5.1
+            def last(limit = nil)
+              ActiveDecorator::Decorator.instance.decorate_association(@association.owner, super)
+            end
+
+            private
+
+            def find_nth_with_limit(index, limit)
+              ActiveDecorator::Decorator.instance.decorate_association(@association.owner, super)
+            end
+
+            def find_nth_from_last(index)
+              ActiveDecorator::Decorator.instance.decorate_association(@association.owner, super)
+            end
           end
         end
       end

--- a/lib/active_decorator/railtie.rb
+++ b/lib/active_decorator/railtie.rb
@@ -33,9 +33,7 @@ module ActiveDecorator
         require 'active_decorator/monkey/active_record/associations'
         ActiveRecord::Associations::Association.send :prepend, ActiveDecorator::Monkey::ActiveRecord::Associations::Association
         ActiveRecord::Associations::CollectionAssociation.send :prepend, ActiveDecorator::Monkey::ActiveRecord::Associations::CollectionAssociation
-        if Rails.version.to_f >= 4.0
-          ActiveRecord::Associations::CollectionProxy.send :prepend, ActiveDecorator::Monkey::ActiveRecord::Associations::CollectionProxy
-        end
+        ActiveRecord::Associations::CollectionProxy.send :prepend, ActiveDecorator::Monkey::ActiveRecord::Associations::CollectionProxy
       end
     end
   end

--- a/test/fake_app/app/views/authors/show.html.erb
+++ b/test/fake_app/app/views/authors/show.html.erb
@@ -1,9 +1,9 @@
 <%= @author.name %>
 <%= @author.capitalized_name %>
 <%= @author.books.first.upcased_title %>
-<%= @author.books[-1].upcased_title %>
+<%= @author.books.last.upcased_title %>
 <% if Rails.version.to_f >= 4.0 && p = @author.publishers.take %><%= p.upcased_name %><% end %>
-<% if p = @author.publishers.last %><%= p.upcased_name %><% end %>
+<% if Rails.version.to_f >= 5.1 && p = @author.publishers.second_to_last %><%= p.reversed_name %><% end %>
 <% if p = @author.profile %><%= p.address %><% end %>
 <% if h = @author.profile_history %><%= h.update_date %><% end %>
 <% if m = @author.magazines.first %><%= m.upcased_title %><% end %>

--- a/test/fake_app/fake_app.rb
+++ b/test/fake_app/fake_app.rb
@@ -123,6 +123,10 @@ module PublisherDecorator
   def upcased_name
     name.upcase
   end
+
+  def reversed_name
+    name.reverse
+  end
 end
 module ProfileDecorator
   def address

--- a/test/features/association_test.rb
+++ b/test/features/association_test.rb
@@ -25,7 +25,9 @@ class AssociationTest < ActionDispatch::IntegrationTest
     if Rails.version.to_f >= 4.0
       assert page.has_content? 'nikkei linux'.upcase
     end
-    assert page.has_content? "o'reilly".upcase
+    if Rails.version.to_f >= 5.1
+      assert page.has_content? 'nikkei linux'.reverse
+    end
     assert page.has_content? 'secret'
     assert page.has_content? '2017/02/07'
     assert page.has_content? 'rubima'.upcase


### PR DESCRIPTION
In Rails 5.1, `ActiveRecord::Associations::CollectionAssociation#find_nth_or_last` is removed ([ref](https://github.com/rails/rails/commit/592e6b7e894e0fff07ab8233fce4bf77968ee8b6#diff-20f545c453ee24942b6f7ae565e9e369L645)), so decorating associations will be broken.
I fix it by monkey-patching to `ActiveRecord::Associations::CollectionProxy`.