### PR TITLE
CI against Rails 5.1.0.rc2

### DIFF
--- a/gemfiles/Gemfile-rails.5.1.x
+++ b/gemfiles/Gemfile-rails.5.1.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'active_decorator', path: '..'
 
-gem 'rails', '5.1.0.rc1'
+gem 'rails', '5.1.0.rc2'
 gem 'test-unit-rails'
 gem 'capybara'
 gem 'sqlite3'


### PR DESCRIPTION
Rails 5.1.0.rc2 has been released.

http://weblog.rubyonrails.org/2017/4/21/Rails-5-1-rc2