### PR TITLE
re-raise irrelevant errors which are not responsible to the gem

### DIFF
--- a/lib/active_decorator/helpers.rb
+++ b/lib/active_decorator/helpers.rb
@@ -4,12 +4,25 @@ module ActiveDecorator
   module Helpers
     def method_missing(method, *args, &block)
       super
-    rescue NoMethodError, NameError
+    rescue NoMethodError, NameError => e
+      if e.name != method
+        # the error is not mine, so just releases it as is.
+        raise e
+      end
+
       begin
         (view_context = ActiveDecorator::ViewContext.current).send method, *args, &block
-      rescue NoMethodError
+      rescue NoMethodError => e
+        if e.name != method
+          raise e
+        end
+
         raise NoMethodError, "undefined method `#{method}` for either #{self} or #{view_context}"
-      rescue NameError
+      rescue NameError => e
+        if e.name != method
+          raise e
+        end
+
         raise NameError, "undefined local variable `#{method}` for either #{self} or #{view_context}"
       end
     end


### PR DESCRIPTION
I have seen that ActiveDecorator's raises NoMethodError for methods which absolutely exist; this is because it handles all the NoMethoderror and NameError raised in irrelevant classes on decorators. It makes debugging harder.

With this PR, AD re-raises errors if they are irrelevant to (and thus not be responsible to) the gem.

