### PR TITLE
Update decorator_spec.rb syntax

### DIFF
--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -1,6 +1,6 @@
 require '<%= File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
 
-describe <%= class_name %>Decorator do
+RSpec.describe <%= class_name %>Decorator do
   let(:<%= singular_name %>) { <%= class_name %>.new.extend <%= class_name %>Decorator }
   subject { <%= singular_name %> }
   it { should be_a <%= class_name %> }


### PR DESCRIPTION
`RSpec.describe` works regardless of settings while `describe` alone lead can result in 
`undefined method 'describe' for main:Object` when tests are run.
https://github.com/rspec/rspec-rails/commit/ca0d249858903949052e06884e8e7f9d596cdc79
https://github.com/rspec/rspec-rails/issues/1048#issuecomment-44609422