### PR TITLE
Fix generator for TestUnit

### DIFF
--- a/lib/generators/rails/USAGE
+++ b/lib/generators/rails/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Stubs out a decorator module in app/decorators directory.
+
+Examples:
+    `rails g decorator book`
+
+    This creates:
+        app/decorators/book_decorator.rb

--- a/lib/generators/rails/decorator_generator.rb
+++ b/lib/generators/rails/decorator_generator.rb
@@ -3,6 +3,7 @@ module Rails
   module Generators
     class DecoratorGenerator < NamedBase
       source_root File.expand_path('../templates', __FILE__)
+      check_class_collision suffix: "Decorator"
 
       def create_decorator_file
         template 'decorator.rb', File.join('app/decorators', class_path, "#{file_name}_decorator.rb")

--- a/lib/generators/rails/decorator_generator.rb
+++ b/lib/generators/rails/decorator_generator.rb
@@ -2,7 +2,7 @@
 module Rails
   module Generators
     class DecoratorGenerator < NamedBase
-      source_root File.expand_path('../templates', __FILE__)
+      source_root File.expand_path("templates", __dir__)
       check_class_collision suffix: "Decorator"
 
       def create_decorator_file

--- a/lib/generators/rails/decorator_generator.rb
+++ b/lib/generators/rails/decorator_generator.rb
@@ -1,19 +1,8 @@
 # frozen_string_literal: true
 module Rails
   module Generators
-    class DecoratorGenerator < Rails::Generators::NamedBase
+    class DecoratorGenerator < NamedBase
       source_root File.expand_path('../templates', __FILE__)
-
-      desc <<DESC
-Description:
-    Stubs out a decorator module in app/decorators directory.
-
-Examples:
-    `rails g decorator book`
-
-    This creates:
-        app/decorators/book_decorator.rb
-DESC
 
       def create_decorator_file
         template 'decorator.rb', File.join('app/decorators', class_path, "#{file_name}_decorator.rb")

--- a/lib/generators/rspec/decorator_generator.rb
+++ b/lib/generators/rspec/decorator_generator.rb
@@ -2,7 +2,7 @@
 module Rspec
   module Generators
     class DecoratorGenerator < ::Rails::Generators::NamedBase
-      source_root File.expand_path('../templates', __FILE__)
+      source_root File.expand_path("templates", __dir__)
 
       def create_spec_file
         template 'decorator_spec.rb', File.join('spec/decorators', class_path, "#{file_name}_decorator_spec.rb")

--- a/lib/generators/rspec/decorator_generator.rb
+++ b/lib/generators/rspec/decorator_generator.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 module Rspec
-  class DecoratorGenerator < ::Rails::Generators::NamedBase
-    source_root File.expand_path('../templates', __FILE__)
+  module Generators
+    class DecoratorGenerator < ::Rails::Generators::NamedBase
+      source_root File.expand_path('../templates', __FILE__)
 
-    def create_spec_file
-      template 'decorator_spec.rb', File.join('spec/decorators', class_path, "#{file_name}_decorator_spec.rb")
+      def create_spec_file
+        template 'decorator_spec.rb', File.join('spec/decorators', class_path, "#{file_name}_decorator_spec.rb")
+      end
     end
   end
 end

--- a/lib/generators/test_unit/decorator_generator.rb
+++ b/lib/generators/test_unit/decorator_generator.rb
@@ -2,7 +2,7 @@
 module TestUnit
   module Generators
     class DecoratorGenerator < ::Rails::Generators::NamedBase
-      source_root File.expand_path('../templates', __FILE__)
+      source_root File.expand_path("templates", __dir__)
       check_class_collision suffix: "DecoratorTest"
 
       def create_test_file

--- a/lib/generators/test_unit/decorator_generator.rb
+++ b/lib/generators/test_unit/decorator_generator.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 module TestUnit
-  class DecoratorGenerator < ::Rails::Generators::NamedBase
-    source_root File.expand_path('../templates', __FILE__)
-    check_class_collision suffix: "DecoratorTest"
+  module Generators
+    class DecoratorGenerator < ::Rails::Generators::NamedBase
+      source_root File.expand_path('../templates', __FILE__)
+      check_class_collision suffix: "DecoratorTest"
 
-    def create_test_file
-      template 'decorator_test.rb', File.join('test/decorators', class_path, "#{file_name}_decorator_test.rb")
+      def create_test_file
+        template 'decorator_test.rb', File.join('test/decorators', class_path, "#{file_name}_decorator_test.rb")
+      end
     end
   end
 end

--- a/lib/generators/test_unit/decorator_generator.rb
+++ b/lib/generators/test_unit/decorator_generator.rb
@@ -2,6 +2,7 @@
 module TestUnit
   class DecoratorGenerator < ::Rails::Generators::NamedBase
     source_root File.expand_path('../templates', __FILE__)
+    check_class_collision suffix: "DecoratorTest"
 
     def create_test_file
       template 'decorator_test.rb', File.join('test/decorators', class_path, "#{file_name}_decorator_test.rb")

--- a/lib/generators/test_unit/templates/decorator_test.rb
+++ b/lib/generators/test_unit/templates/decorator_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 
-<% module_namespacing do -%>
 class <%= class_name %>DecoratorTest < ActiveSupport::TestCase
   def setup
     @<%= singular_name %> = <%= class_name %>.new.extend <%= class_name %>Decorator
@@ -10,4 +9,3 @@ class <%= class_name %>DecoratorTest < ActiveSupport::TestCase
   #   assert true
   # end
 end
-<% end -%>

--- a/lib/generators/test_unit/templates/decorator_test.rb
+++ b/lib/generators/test_unit/templates/decorator_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
-class <%= singular_name.camelize %>DecoratorTest < ActiveSupport::TestCase
+<% module_namespacing do -%>
+class <%= class_name %>DecoratorTest < ActiveSupport::TestCase
   def setup
     @<%= singular_name %> = <%= class_name %>.new.extend <%= class_name %>Decorator
   end
@@ -9,3 +10,4 @@ class <%= singular_name.camelize %>DecoratorTest < ActiveSupport::TestCase
   #   assert true
   # end
 end
+<% end -%>


### PR DESCRIPTION
I found namespace problem in generator for TestUnit:

### Example

```bash
$ bin/rails g decorator user
$ bin/rails g decorator admin/user
```

#### Before

```ruby
# test/decorators/user_decorator_test.rb
require 'test_helper'

class UserDecoratorTest < ActiveSupport::TestCase
  def setup
    @user = User.new.extend UserDecorator
  end

  # test "the truth" do
  #   assert true
  # end
end

# test/decorators/admin/user_decorator_test.rb
require 'test_helper'

class UserDecoratorTest < ActiveSupport::TestCase # it does not have namespace :(
  def setup
    @user = Admin::User.new.extend Admin::UserDecorator
  end

  # test "the truth" do
  #   assert true
  # end
end
```

#### After

```ruby
# test/decorators/user_decorator_test.rb
require 'test_helper'

class UserDecoratorTest < ActiveSupport::TestCase
  def setup
    @user = User.new.extend UserDecorator
  end

  # test "the truth" do
  #   assert true
  # end
end

# test/decorators/admin/user_decorator_test.rb
require 'test_helper'

class Admin::UserDecoratorTest < ActiveSupport::TestCase # namespaced class :D
  def setup
    @user = Admin::User.new.extend Admin::UserDecorator
  end

  # test "the truth" do
  #   assert true
  # end
end
```

And I've refactored with cosme:

- Separeted desc to `USAGE` on Rails::Generators::DecoratorGenerator
- Added `check_class_collision` to generators
- Using same namespace:
  - `TestUnit::DecoratorGenerator` => `TestUnit::Generators::DecoratorGenerator`. [here](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/test_unit.rb#L4)
  - `Rspec::DecoratorGenerator` => `Rspec::Generators::DecoratorGenerator`. [here](https://github.com/rspec/rspec-rails/blob/master/lib/generators/rspec.rb#L9)

Thanks a lot!