### PR TITLE
Fix ActiveRecord::Relation which decorated return nil when `decorate` is called

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -33,9 +33,11 @@ module ActiveDecorator
         if obj.respond_to?(:records)
           # Rails 5.0
           obj.extend ActiveDecorator::RelationDecorator unless obj.is_a? ActiveDecorator::RelationDecorator
+          obj
         else
           # Rails 3.x and 4.x
           obj.extend ActiveDecorator::RelationDecoratorLegacy unless obj.is_a? ActiveDecorator::RelationDecoratorLegacy
+          obj
         end
       else
         if defined?(ActiveRecord) && obj.is_a?(ActiveRecord::Base) && !obj.is_a?(ActiveDecorator::Decorated)

--- a/test/decorator_test.rb
+++ b/test/decorator_test.rb
@@ -12,4 +12,22 @@ class DecoratorTest < Test::Unit::TestCase
     book = Book.new title: 'Boek'
     assert_equal book, ActiveDecorator::Decorator.instance.decorate(ActiveDecorator::Decorator.instance.decorate(book))
   end
+
+  test 'it returns the object of ActiveRecord::Relation on decorate' do
+    3.times do |index|
+      Book.create title: "ve#{index}"
+    end
+
+    books = Book.all
+    assert_equal books, ActiveDecorator::Decorator.instance.decorate(books)
+  end
+
+  test 'it returns the object of ActiveRecord::Relation when it already is decorated on decorate' do
+    3.times do |index|
+      Book.create title: "ve#{index}"
+    end
+
+    books = Book.all
+    assert_equal books, ActiveDecorator::Decorator.instance.decorate(ActiveDecorator::Decorator.instance.decorate(books))
+  end
 end


### PR DESCRIPTION
Hi, I started using active_decorator, it's great!

but, I find bug.
When we decorate ActiveRecord::Relation which already decorated,  `ActiveDecorator::Decorator#decorate` returns `nil`.
So, I fix, if ActiveRecord::Relation is already decorated, `ActiveDecorator::Decorator#decorate` returns object.