### PR TITLE
Improve ActionController::API support.

### DIFF
--- a/lib/active_decorator/railtie.rb
+++ b/lib/active_decorator/railtie.rb
@@ -22,14 +22,22 @@ module ActiveDecorator
       end
 
       if Rails::VERSION::MAJOR >= 5
-        ActiveSupport.on_load :action_controller_api do
-          require 'active_decorator/monkey/abstract_controller/rendering'
-          ::ActionController::API.send :prepend, ActiveDecorator::Monkey::AbstractController::Rendering
+        module ::ActionController
+          module ApiRendering
+            include ActionView::Rendering
+          end
+        end
 
-          require 'active_decorator/monkey/action_controller/base/rescue_from'
-          ::ActionController::API.send :prepend, ActiveDecorator::Monkey::ActionController::Base
+        ActiveSupport.on_load :action_controller do
+          if self == ActionController::API
+            require 'active_decorator/monkey/abstract_controller/rendering'
+            ::ActionController::API.send :prepend, ActiveDecorator::Monkey::AbstractController::Rendering
 
-          ::ActionController::API.send :include, ActiveDecorator::ViewContext::Filter
+            require 'active_decorator/monkey/action_controller/base/rescue_from'
+            ::ActionController::API.send :prepend, ActiveDecorator::Monkey::ActionController::Base
+
+            ::ActionController::API.send :include, ActiveDecorator::ViewContext::Filter
+          end
         end
       end
 


### PR DESCRIPTION
- The `:action_controller_api` hook is only included in Rails 5.2+.

- Adds support for using active_decorator without JBuilder.

@amatsuda Sorry for the mess with the previous pull request, I accidentally deleted my fork 🙇. Thanks for releasing a new version!

Fixes #95 