### PR TITLE
Fix wrong decoration for nested classes

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -69,7 +69,7 @@ module ActiveDecorator
       return @@decorators[model_class] if @@decorators.key? model_class
 
       decorator_name = "#{model_class.name}#{ActiveDecorator.config.decorator_suffix}"
-      d = Object.const_get decorator_name, false
+      d = decorator_name.constantize
       unless Class === d
         d.send :include, ActiveDecorator::Helpers
         @@decorators[model_class] = d

--- a/test/decorator_test.rb
+++ b/test/decorator_test.rb
@@ -48,4 +48,11 @@ class DecoratorTest < Test::Unit::TestCase
       assert value.is_a?(BookDecorator)
     end
   end
+
+  test "Don't use the wrong decorator for nested classes" do
+    comic = Foo::Comic.new
+
+    assert_equal comic, ActiveDecorator::Decorator.instance.decorate(comic)
+    assert !comic.is_a?(ComicDecorator)
+  end
 end

--- a/test/fake_app/app/decorators/comic_decorator.rb
+++ b/test/fake_app/app/decorators/comic_decorator.rb
@@ -1,0 +1,3 @@
+# decorator to test auto-loading behavior
+# this module is intended not to be loaded.
+module ComicDecorator; end

--- a/test/fake_app/fake_app.rb
+++ b/test/fake_app/fake_app.rb
@@ -277,3 +277,7 @@ class RelationProxy < BasicObject
     @ar_relation.public_send(method, *args, &block)
   end
 end
+
+module Foo
+  class Comic; end
+end


### PR DESCRIPTION
ActiveDecorator decorates incorrectly for the nested class that do not define decorator.

```ruby
comic = Foo::Comic.new
ActiveDecorator::Decorator.instance.decorate(comic)
comic.is_a?(ComicDecorator)  #=> true
```

If `Foo::ComicDecorator` is not defined, it should not use `ComicDecorator` instead of `Foo::ComicDecorator`.
The cause of the problem is 73dcdd67ae146ee9e76b1da9ae9e9dbd55529193, so we will revert it.