### PR TITLE
Fix a bug occurs when request spec targets contollers inherited AC::API

### DIFF
--- a/lib/active_decorator/monkey/action_controller/base/rescue_from.rb
+++ b/lib/active_decorator/monkey/action_controller/base/rescue_from.rb
@@ -7,10 +7,10 @@ module ActiveDecorator
     module ActionController
       module Base
         def rescue_with_handler(*)
-          ActiveDecorator::ViewContext.push(view_context)
+          ActiveDecorator::ViewContext.push(view_context) if defined?(view_context)
           super
         ensure
-          ActiveDecorator::ViewContext.pop
+          ActiveDecorator::ViewContext.pop if defined?(view_context)
         end
       end
     end


### PR DESCRIPTION
Hi there.

I have a issue that a error shows up when I run request rspecs that target controllers inherit ActionController::API and this Rails app uses ActiveDecorator.
Probably this is related #102 .

Plz confirm it.

## backtrace
https://gist.github.com/kamillle/15b575a0b6f12583e28bc102202fe288

```
NameError: undefined local variable or method `view_context' for #<TestController:0x00007fd232cc0f40>
Did you mean?  view_runtime> with backtrace:
  # ./.bundle/gems/active_decorator-1.3.0/lib/active_decorator/monkey/action_controller/base/rescue_from.rb:10:in `rescue_with_handler'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_controller/metal/rescue.rb:25:in `rescue in process_action'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_controller/metal/rescue.rb:21:in `process_action'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `block in instrument'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `instrument'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_controller/metal/params_wrapper.rb:256:in `process_action'
  # ./.bundle/gems/activerecord-5.2.3/lib/active_record/railties/controller_runtime.rb:24:in `process_action'
  # ./.bundle/gems/actionpack-5.2.3/lib/abstract_controller/base.rb:134:in `process'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_controller/metal.rb:191:in `dispatch'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_controller/metal.rb:252:in `dispatch'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/routing/route_set.rb:52:in `dispatch'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/routing/route_set.rb:34:in `serve'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/journey/router.rb:52:in `block in serve'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/journey/router.rb:35:in `each'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/journey/router.rb:35:in `serve'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/routing/route_set.rb:840:in `call'
  # ./.bundle/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:192:in `call!'
  # ./.bundle/gems/omniauth-1.9.0/lib/omniauth/strategy.rb:169:in `call'
  # ./.bundle/gems/omniauth-1.9.0/lib/omniauth/builder.rb:64:in `call'
  # ./.bundle/gems/bullet-6.0.1/lib/bullet/rack.rb:15:in `call'
  # ./.bundle/gems/rack-2.0.7/lib/rack/tempfile_reaper.rb:15:in `call'
  # ./.bundle/gems/warden-1.2.8/lib/warden/manager.rb:36:in `block in call'
  # ./.bundle/gems/warden-1.2.8/lib/warden/manager.rb:34:in `catch'
  # ./.bundle/gems/warden-1.2.8/lib/warden/manager.rb:34:in `call'
  # ./.bundle/gems/rack-2.0.7/lib/rack/tempfile_reaper.rb:15:in `call'
  # ./.bundle/gems/rack-2.0.7/lib/rack/etag.rb:25:in `call'
  # ./.bundle/gems/rack-2.0.7/lib/rack/conditional_get.rb:25:in `call'
  # ./.bundle/gems/rack-2.0.7/lib/rack/head.rb:12:in `call'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/http/content_security_policy.rb:18:in `call'
  # ./.bundle/gems/rack-2.0.7/lib/rack/session/abstract/id.rb:232:in `context'
  # ./.bundle/gems/rack-2.0.7/lib/rack/session/abstract/id.rb:226:in `call'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/middleware/cookies.rb:670:in `call'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:98:in `run_callbacks'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
  # ./.bundle/gems/rollbar-2.21.0/lib/rollbar/middleware/rails/rollbar.rb:25:in `block in call'
  # ./.bundle/gems/rollbar-2.21.0/lib/rollbar.rb:145:in `scoped'
  # ./.bundle/gems/rollbar-2.21.0/lib/rollbar/middleware/rails/rollbar.rb:22:in `call'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'
  # ./.bundle/gems/rollbar-2.21.0/lib/rollbar/middleware/rails/show_exceptions.rb:22:in `call_with_rollbar'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
  # ./.bundle/gems/railties-5.2.3/lib/rails/rack/logger.rb:38:in `call_app'
  # ./.bundle/gems/railties-5.2.3/lib/rails/rack/logger.rb:26:in `block in call'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71:in `block in tagged'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:28:in `tagged'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71:in `tagged'
  # ./.bundle/gems/railties-5.2.3/lib/rails/rack/logger.rb:26:in `call'
  # ./.bundle/gems/sprockets-rails-3.2.1/lib/sprockets/rails/quiet_assets.rb:13:in `call'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
  # ./.bundle/gems/request_store-1.4.1/lib/request_store/middleware.rb:19:in `call'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/middleware/request_id.rb:27:in `call'
  # ./.bundle/gems/rack-2.0.7/lib/rack/method_override.rb:22:in `call'
  # ./.bundle/gems/rack-2.0.7/lib/rack/runtime.rb:22:in `call'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/middleware/executor.rb:14:in `call'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/middleware/static.rb:127:in `call'
  # ./.bundle/gems/rack-2.0.7/lib/rack/sendfile.rb:111:in `call'
  # ./.bundle/gems/railties-5.2.3/lib/rails/engine.rb:524:in `call'
  # ./.bundle/gems/rack-test-1.1.0/lib/rack/mock_session.rb:29:in `request'
  # ./.bundle/gems/rack-test-1.1.0/lib/rack/test.rb:266:in `process_request'
  # ./.bundle/gems/rack-test-1.1.0/lib/rack/test.rb:119:in `request'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/testing/integration.rb:263:in `process'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/testing/integration.rb:18:in `get'
  # ./.bundle/gems/actionpack-5.2.3/lib/action_dispatch/testing/integration.rb:350:in `block (2 levels) in <module:Runner>'
  # ./spec/requests/tests_spec.rb:31:in `block (3 levels) in <main>'
  # ./spec/requests/tests_spec.rb:34:in `block (4 levels) in <main>'
  # ./spec/requests/tests_spec.rb:34:in `block (3 levels) in <main>'
  # ./.bundle/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
  # ./.bundle/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `block in load'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
  # ./.bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `load'
  # ./.bundle/gems/spring-commands-rspec-1.0.4/lib/spring/commands/rspec.rb:18:in `call'
  # -e:1:in `<main>'
```

## test code
```rb
class TestsController < ActionController:API
  rescue_from Exception do |e|
    head :internal_server_error
  end

  def new
    raise
  end
end

RSpec.describe TestsContoller, type: :request do
  describe '#new' do
    subject { get :new_test_url }
    
    it do
      is_expected.to have_http_status :internal_server_error
    end
  end
end
```