### PR TITLE
Decorate models where nil? returns true

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -24,7 +24,6 @@ module ActiveDecorator
     # This method can be publicly called from anywhere by `ActiveDecorator::Decorator.instance.decorate(obj)`.
     def decorate(obj)
       return if defined?(Jbuilder) && (Jbuilder === obj)
-      return if obj.nil?
 
       if obj.is_a?(Array)
         obj.each do |r|

--- a/test/decorator_test.rb
+++ b/test/decorator_test.rb
@@ -55,4 +55,11 @@ class DecoratorTest < Test::Unit::TestCase
     assert_equal comic, ActiveDecorator::Decorator.instance.decorate(comic)
     assert !comic.is_a?(ComicDecorator)
   end
+
+  test "it returns the object when nil? returns true on decorate" do
+    record = NilRecord.new
+
+    assert_equal record, ActiveDecorator::Decorator.instance.decorate(record)
+    assert record.is_a?(NilRecordDecorator)
+  end
 end

--- a/test/fake_app/fake_app.rb
+++ b/test/fake_app/fake_app.rb
@@ -99,6 +99,11 @@ class Company < ActiveRecord::Base
 end
 class Bookstore < ActiveRecord::Base
 end
+class NilRecord < ActiveRecord::Base
+  def nil?
+    true
+  end
+end
 
 # helpers
 module ApplicationHelper; end
@@ -180,6 +185,7 @@ module BookstoreDecorator
     {name: name, initial: initial}
   end
 end
+module NilRecordDecorator; end
 
 # decorator fake
 class MovieDecorator; end
@@ -303,6 +309,7 @@ class CreateAllTables < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migrat
     create_table(:authors_magazines) {|t| t.references :author; t.references :magazine}
     create_table(:companies) {|t| t.string :name}
     create_table(:bookstores) {|t| t.string :name}
+    create_table(:nil_records) {|t| t.string :name}
   end
 end
 


### PR DESCRIPTION
A model may implement or delegate `nil?` to check the value of an attribute rather than the object instance as a whole.

Action Text implemented `nil?` in this way and as a result decorating a model which has Action Text rich-text fields where those fields have empty contents will cause problems accessing the associated `ActionText::RichText` record after decoration.

e.g. https://github.com/rails/rails/blob/da5b1c3bb7041af03d5c24bce2639349f7fcb5c2/actiontext/app/models/action_text/rich_text.rb#L12