### PR TITLE
Fix Ruby 2.7 keyword arguments warning

### DIFF
--- a/lib/active_decorator/helpers.rb
+++ b/lib/active_decorator/helpers.rb
@@ -25,5 +25,6 @@ module ActiveDecorator
         raise e1
       end
     end
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
   end
 end


### PR DESCRIPTION
This pull request fixes Ruby 2.7 keyword arguments warning.


# Problem

Currently active_decorator displays keyword arguments warning on a view context method calling with keyword arguments.

For example


```ruby
user.decorate.t('key.of.translation', value: 'foo')
```

```
/path/to/active_decorator-1.3.2/lib/active_decorator/helpers.rb:14: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/actionview-6.0.3.2/lib/action_view/helpers/translation_helper.rb:60: warning: The called method `t' is defined here
```


# Solution

Use `ruby2_keywords` method to suppress the warnings.

Note that `def method_missing(method, *args, **kwargs, &block)` doesn't work on Ruby 2.6.
Because `Object#send` has different behaviors between Ruby 2.6 and 2.7.

```ruby
def m(*args)
  p args
end

args = []
kwargs = {}
send :m, *args, **kwargs
# with 2.6 => [{}]
# with 2.7 => []
```


It causes `ArgumentError` for view context method calling if the method doesn't accept any arguments.
For example

```ruby
class userDecorator
  def something
  end
end

user.decorate.something
# => wrong number of arguments (given 1, expected 0)
# Because `something` expects no arguments, but the `method_missing` passes an emty hash via `send` method.
```
