### PR TITLE
Support Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,21 @@ cache: bundler
 matrix:
   include:
     - rvm: 2.7.1
+      gemfile: gemfiles/Gemfile-rails.6.1.x
+    - rvm: 2.7.1
+      gemfile: gemfiles/Gemfile-rails.6.1.x
+      env: API=1
+    - rvm: 2.7.1
       gemfile: gemfiles/Gemfile-rails.6.0.x
     - rvm: 2.7.1
       gemfile: gemfiles/Gemfile-rails.6.0.x
       env: API=1
 
+    - rvm: 2.6.6
+      gemfile: gemfiles/Gemfile-rails.6.1.x
+    - rvm: 2.6.6
+      gemfile: gemfiles/Gemfile-rails.6.1.x
+      env: API=1
     - rvm: 2.6.6
       gemfile: gemfiles/Gemfile-rails.6.0.x
     - rvm: 2.6.6

--- a/gemfiles/Gemfile-rails.6.1.x
+++ b/gemfiles/Gemfile-rails.6.1.x
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 6.1.0'
+gem 'webdrivers'
+gem 'jbuilder' unless ENV['API']

--- a/lib/active_decorator/monkey/action_view/collection_renderer.rb
+++ b/lib/active_decorator/monkey/action_view/collection_renderer.rb
@@ -1,0 +1,12 @@
+module ActiveDecorator
+  module Monkey
+    module ActionView
+      module CollectionRenderer
+        def render_collection_with_partial(collection, *)
+          ActiveDecorator::Decorator.instance.decorate collection
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/active_decorator/monkey/action_view/object_renderer.rb
+++ b/lib/active_decorator/monkey/action_view/object_renderer.rb
@@ -1,0 +1,12 @@
+module ActiveDecorator
+  module Monkey
+    module ActionView
+      module ObjectRenderer
+        def render_object_with_partial(object, *)
+          ActiveDecorator::Decorator.instance.decorate object
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/active_decorator/monkey/action_view/partial_renderer.rb
+++ b/lib/active_decorator/monkey/action_view/partial_renderer.rb
@@ -5,18 +5,30 @@ module ActiveDecorator
   module Monkey
     module ActionView
       module PartialRenderer
+        if Rails.version.to_f >= 6.1
+          def initialize(*)
+            super
+
+            @locals.each_value do |v|
+              ActiveDecorator::Decorator.instance.decorate v
+            end
+          end
+        end
+
         private
 
-        def setup(*)
-          super
+        if Rails.version.to_f < 6.1
+          def setup(*)
+            super
 
-          @locals.each_value do |v|
-            ActiveDecorator::Decorator.instance.decorate v
-          end if @locals
-          ActiveDecorator::Decorator.instance.decorate @object if @object
-          ActiveDecorator::Decorator.instance.decorate @collection unless @collection.blank?
+            @locals.each_value do |v|
+              ActiveDecorator::Decorator.instance.decorate v
+            end if @locals
+            ActiveDecorator::Decorator.instance.decorate @object if @object
+            ActiveDecorator::Decorator.instance.decorate @collection unless @collection.blank?
 
-          self
+            self
+          end
         end
       end
     end

--- a/lib/active_decorator/railtie.rb
+++ b/lib/active_decorator/railtie.rb
@@ -6,6 +6,14 @@ module ActiveDecorator
       ActiveSupport.on_load :action_view do
         require 'active_decorator/monkey/action_view/partial_renderer'
         ActionView::PartialRenderer.send :prepend, ActiveDecorator::Monkey::ActionView::PartialRenderer
+
+        if Rails.version.to_f >= 6.1
+          require 'active_decorator/monkey/action_view/collection_renderer'
+          ActionView::CollectionRenderer.send :prepend, ActiveDecorator::Monkey::ActionView::CollectionRenderer
+
+          require 'active_decorator/monkey/action_view/object_renderer'
+          ActionView::ObjectRenderer.send :prepend, ActiveDecorator::Monkey::ActionView::ObjectRenderer
+        end
       end
 
       ActiveSupport.on_load :action_controller do

--- a/test/fake_app/app/views/authors/_author.html.erb
+++ b/test/fake_app/app/views/authors/_author.html.erb
@@ -1,0 +1,2 @@
+<%= author.name %>
+<%= author.reverse_name %>

--- a/test/fake_app/app/views/authors/_author_locals.html.erb
+++ b/test/fake_app/app/views/authors/_author_locals.html.erb
@@ -1,0 +1,2 @@
+<%= a.name %>
+<%= a.reverse_name %>

--- a/test/fake_app/app/views/authors/index.html.erb
+++ b/test/fake_app/app/views/authors/index.html.erb
@@ -1,16 +1,4 @@
 <% @authors.each do |author| %>
   <%= author.name %>
   <%= author.reverse_name %>
-
-  <% if params[:partial] == 'collection' %>
-    <%= render author.books %>
-  <% elsif params[:partial] == 'locals' %>
-    <% author.books.each do |book| %>
-      <%= render partial: 'books/book_locals', locals: {b: book} %>
-    <% end %>
-  <% else %>
-    <% author.books.each do |book| %>
-      <%= render book %>
-    <% end %>
-  <% end %>
 <% end %>

--- a/test/fake_app/fake_app.rb
+++ b/test/fake_app/fake_app.rb
@@ -29,6 +29,9 @@ ActiveDecoratorTestApp::Application.initialize!
 # routes
 ActiveDecoratorTestApp::Application.routes.draw do
   resources :authors, only: [:index, :show] do
+    collection do
+      get :partial
+    end
     resources :books, only: [:index, :show] do
       member do
         get :errata
@@ -200,6 +203,16 @@ unless ENV['API']
 
     def show
       @author = Author.find params[:id]
+    end
+
+    def partial
+      if params[:pattern] == 'collection'
+        render partial: 'authors/author', collection: @authors = Author.all
+      elsif params[:pattern] == 'locals'
+        render partial: 'authors/author_locals', locals: {a: Author.first}
+      else
+        render Author.first
+      end
     end
   end
   class BooksController < ApplicationController

--- a/test/features/partial_test.rb
+++ b/test/features/partial_test.rb
@@ -5,25 +5,23 @@ require 'test_helper'
 class PartialTest < ActionDispatch::IntegrationTest
   setup do
     Author.create! name: 'aamine'
-    nari = Author.create! name: 'nari'
-    nari.books.create! title: 'the gc book'
   end
 
   test 'decorating implicit @object' do
-    visit '/authors'
-    assert page.has_content? 'the gc book'
-    assert page.has_content? 'the gc book'.reverse
+    visit '/authors/partial'
+    assert page.has_content? 'aamine'
+    assert page.has_content? 'aamine'.reverse
   end
 
   test 'decorating implicit @collection' do
-    visit '/authors?partial=collection'
-    assert page.has_content? 'the gc book'
-    assert page.has_content? 'the gc book'.reverse
+    visit '/authors/partial?pattern=collection'
+    assert page.has_content? 'aamine'
+    assert page.has_content? 'aamine'.reverse
   end
 
   test 'decorating objects in @locals' do
-    visit '/authors?partial=locals'
-    assert page.has_content? 'the gc book'
-    assert page.has_content? 'the gc book'.upcase
+    visit '/authors/partial?pattern=locals'
+    assert page.has_content? 'aamine'
+    assert page.has_content? 'aamine'.reverse
   end
 end


### PR DESCRIPTION
`PartialRenderer` was refactored by rails/rails#38594 This fixes to follow to new render behavior.

Also, updated tests for `partial`. Because objects of original tests were decorated via `RelationDecorator#records` and didn't affected by `PartialRenderer` monkey.