### PR TITLE
Fixed decoration failing with ApplicationController.renderer.render in Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,15 @@ cache: bundler
 matrix:
   include:
     - rvm: 2.7.1
+      gemfile: gemfiles/Gemfile-rails.6.1.x
+    - rvm: 2.7.1
+      gemfile: gemfiles/Gemfile-rails.6.1.x
+      env: API=1
+    - rvm: 2.6.6
+      gemfile: gemfiles/Gemfile-rails.6.1.x
+    - rvm: 2.6.6
+      gemfile: gemfiles/Gemfile-rails.6.1.x
+    - rvm: 2.7.1
       gemfile: gemfiles/Gemfile-rails.6.0.x
     - rvm: 2.7.1
       gemfile: gemfiles/Gemfile-rails.6.0.x

--- a/gemfiles/Gemfile-rails.6.1.x
+++ b/gemfiles/Gemfile-rails.6.1.x
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 6.1.0'
+gem 'webdrivers'
+gem 'jbuilder' unless ENV['API']

--- a/lib/active_decorator/monkey/action_view/partial_renderer.rb
+++ b/lib/active_decorator/monkey/action_view/partial_renderer.rb
@@ -5,18 +5,33 @@ module ActiveDecorator
   module Monkey
     module ActionView
       module PartialRenderer
+
+        if (Rails::VERSION::MAJOR > 6) || (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1)
+          def render(*)
+            @locals.each_value do |v|
+              ActiveDecorator::Decorator.instance.decorate v
+            end if @locals
+            ActiveDecorator::Decorator.instance.decorate @object if @object
+            ActiveDecorator::Decorator.instance.decorate @collection unless @collection.blank?
+
+            super
+          end
+        end
+
         private
 
-        def setup(*)
-          super
+        if (Rails::VERSION::MAJOR < 6) || (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR < 1)
+          def setup(*)
+            super
 
-          @locals.each_value do |v|
-            ActiveDecorator::Decorator.instance.decorate v
-          end if @locals
-          ActiveDecorator::Decorator.instance.decorate @object if @object
-          ActiveDecorator::Decorator.instance.decorate @collection unless @collection.blank?
+            @locals.each_value do |v|
+              ActiveDecorator::Decorator.instance.decorate v
+            end if @locals
+            ActiveDecorator::Decorator.instance.decorate @object if @object
+            ActiveDecorator::Decorator.instance.decorate @collection unless @collection.blank?
 
-          self
+            self
+          end
         end
       end
     end

--- a/test/features/action_controller_renderer_test.rb
+++ b/test/features/action_controller_renderer_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActionControllerRendererTest < ActionDispatch::IntegrationTest
+  setup do
+    @matz = Author.create! name: 'matz'
+    @world_of_code = @matz.books.create! title: 'the world of code'
+  end
+
+  test 'decorating a model object in ivar' do
+    content = ApplicationController.renderer.render(partial: 'books/book', locals: { book: @world_of_code })
+    assert content.include? 'the world of code'
+    assert content.include? 'the world of code'.reverse
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require 'rails'
 # load the plugin
 require 'active_decorator'
 
+require 'bundler'
 Bundler.require
 require 'capybara'
 require 'selenium/webdriver'


### PR DESCRIPTION
[ActionView::PartialRenderer](https://github.com/rails/rails/blob/master/actionview/lib/action_view/renderer/partial_renderer.rb) in Rails 6.1 has changed so that #render no longer calls #setup, which is what ActiveDecorator is currently patching.

Test for ApplicationController.renderer.render has been added and #setup is now patched in Rails 6.1+ to resolve this. Fixes #112