### PR TITLE
Replace `File.exists?` with `File.exist?`

### DIFF
--- a/lib/generators/rspec/templates/decorator_spec.rb
+++ b/lib/generators/rspec/templates/decorator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require '<%= File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
+require '<%= File.exist?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
 
 RSpec.describe <%= class_name %>Decorator do
   let(:<%= singular_name %>) { <%= class_name %>.new.extend <%= class_name %>Decorator }

--- a/test/generators/rspec/decorator_generator_test.rb
+++ b/test/generators/rspec/decorator_generator_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rails/generators'
+require 'generators/rspec/decorator_generator'
+
+class DecoratorGeneratorTest < Rails::Generators::TestCase
+  tests Rspec::Generators::DecoratorGenerator
+  destination Rails.root.join('tmp/generators')
+  setup :prepare_destination
+
+  test 'generator runs without errors' do
+    assert_nothing_raised do
+      run_generator ['decorator']
+    end
+  end
+end


### PR DESCRIPTION
`File.exists?` will be removed in Ruby 3.2.

https://www.ruby-lang.org/en/news/2022/11/11/ruby-3-2-0-preview3-released/

With the test.