### PR TITLE
Add CI for Rails 8.1 and Ruby 4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby_version: [ruby-head, '3.4', '3.3', '3.2', '3.1']
-        rails_version: [edge, '8.0', '7.2', '7.1', '7.0', '6.1']
+        rails_version: [edge, '8.1', '8.0', '7.2', '7.1', '7.0', '6.1']
         api: ['0', '1']
 
         include:
@@ -108,6 +108,11 @@ jobs:
             rails_version: edge
           - ruby_version: '3.1'
             rails_version: edge
+            api: '1'
+          - ruby_version: '3.1'
+            rails_version: '8.1'
+          - ruby_version: '3.1'
+            rails_version: '8.1'
             api: '1'
           - ruby_version: '3.1'
             rails_version: '8.0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     name: Ruby ${{ matrix.ruby_version }} / Rails ${{ matrix.rails_version }}${{ matrix.api == '1' && ' / API' || '' }}
     strategy:
       matrix:
-        ruby_version: [ruby-head, '3.4', '3.3', '3.2', '3.1']
+        ruby_version: [ruby-head, '4.0', '3.4', '3.3', '3.2', '3.1']
         rails_version: [edge, '8.1', '8.0', '7.2', '7.1', '7.0', '6.1']
         api: ['0', '1']
 
@@ -118,6 +118,16 @@ jobs:
             rails_version: '8.0'
           - ruby_version: '3.1'
             rails_version: '8.0'
+            api: '1'
+          - ruby_version: '4.0'
+            rails_version: '6.1'
+          - ruby_version: '4.0'
+            rails_version: '6.1'
+            api: '1'
+          - ruby_version: ruby-head
+            rails_version: '6.1'
+          - ruby_version: ruby-head
+            rails_version: '6.1'
             api: '1'
 
     env:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A simple and Rubyish view helper for Rails 4, Rails 5, Rails 6, Rails 7, and Rai
 
 * Ruby 2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, 3.0.x, 3.1.x, 3.2.x, 3.3.x, 3.4.x, and 3.5 (trunk)
 
-* Rails 4.2.x, 5.0, 5.1, 5.2, 6.0, 6.1, 7.0, 7.1, 7.2, 8.0, and 8.1 (edge)
+* Rails 4.2.x, 5.0, 5.1, 5.2, 6.0, 6.1, 7.0, 7.1, 7.2, 8.0, 8.1, and 8.2 (edge)
 
 
 ## Supported ORMs ##

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A simple and Rubyish view helper for Rails 4, Rails 5, Rails 6, Rails 7, and Rai
 
 ## Supported versions ##
 
-* Ruby 2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, 3.0.x, 3.1.x, 3.2.x, 3.3.x, 3.4.x, and 3.5 (trunk)
+* Ruby 2.1.x, 2.2.x, 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, 3.0.x, 3.1.x, 3.2.x, 3.3.x, 3.4.x, 4.0.x, and 4.1 (trunk)
 
 * Rails 4.2.x, 5.0, 5.1, 5.2, 6.0, 6.1, 7.0, 7.1, 7.2, 8.0, 8.1, and 8.2 (edge)
 


### PR DESCRIPTION
- Add Rails 8.1 to GitHub Actions workflow matrix
- Add Ruby 4.0 to GitHub Actions workflow matrix
- Update README.md

follow [Rails 8.1 Release](https://guides.rubyonrails.org/8_1_release_notes.html).
follow [Ruby 4.0 Release](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/).